### PR TITLE
Use forked softfloat-sys to make wrapper complable to wasm32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/.vscode
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,14 @@ edition = "2018"
 
 [features]
 f128 = []
+concordium = ["dep:concordium-std"]
 
 [dependencies]
 num-traits = "0.2.12"
+
+[dependencies.concordium-std]
+version = "4.0"
+optional = true
 
 [dependencies.softfloat-sys]
 git = "https://github.com/target-san/softfloat-sys.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ f128 = []
 num-traits = "0.2.12"
 
 [dependencies.softfloat-sys]
-git = "https://github.com/tacanslabs/softfloat-sys.git"
+git = "https://github.com/target-san/softfloat-sys.git"
 rev = "7017872241262d26cb5bbdc72da50869b99ae4df"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ f128 = []
 num-traits = "0.2.12"
 
 [dependencies.softfloat-sys]
-path = "../softfloat-sys"
+git = "https://github.com/tacanslabs/softfloat-sys.git"
+rev = "7017872241262d26cb5bbdc72da50869b99ae4df"
 
 [dev-dependencies]
 simple-soft-float = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-f128 = []
 concordium = ["dep:concordium-std"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softfloat-wrapper"
-version = "0.3.4-pre"
+version = "0.4.0"
 authors = ["dalance@gmail.com"]
 repository = "https://github.com/dalance/softfloat-wrapper"
 keywords = ["softfloat"]
@@ -23,8 +23,8 @@ version = "4.0"
 optional = true
 
 [dependencies.softfloat-sys]
-git = "https://github.com/target-san/softfloat-sys.git"
-rev = "7017872241262d26cb5bbdc72da50869b99ae4df"
+git = "https://github.com/tacanslabs/softfloat-sys.git"
+rev = "9d99f3566e46984a2f016f173998a7dc27ab3c47"
 
 [dev-dependencies]
 simple-soft-float = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default              = ["8086-sse"]
-8086                 = ["softfloat-sys/8086"]
-8086-sse             = ["softfloat-sys/8086-sse"]
-arm-vfpv2            = ["softfloat-sys/arm-vfpv2"]
-arm-vfpv2-defaultnan = ["softfloat-sys/arm-vfpv2-defaultnan"]
-riscv                = ["softfloat-sys/riscv"]
+f128 = []
 
 [dependencies]
 num-traits = "0.2.12"
 
 [dependencies.softfloat-sys]
-version = "0.1.3"
-default-features = false
+path = "../softfloat-sys"
 
 [dev-dependencies]
 simple-soft-float = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@ softfloat-wrapper is a safe wrapper of [Berkeley SoftFloat](https://github.com/u
 [![Crates.io](https://img.shields.io/crates/v/softfloat-wrapper.svg)](https://crates.io/crates/softfloat-wrapper)
 [![Docs.rs](https://docs.rs/softfloat-wrapper/badge.svg)](https://docs.rs/softfloat-wrapper)
 
+# Requirements
+
+* Rust 1.64 - `core::ffi` types in stable
+* `rustfmt` - used by `bindgen` to format bindings
+* `clang` and `libclang` - used by `bindgen` to generate some bindings
+
 ## Usage
 
 ```Cargo.toml
-[dependencies]
-softfloat-wrapper = "0.3.3"
+[dependencies.softfloat-wrapper]
+git = "https://github.com/tacanslabs/softfloat-sys.git"
 ```
 
 ## Example
@@ -33,24 +39,19 @@ fn main() {
 }
 ```
 
-## Feature
+## Features
 
-Some architectures are supported:
+Compared to 0.3.x, architecture specializations are chosen through target triple.
+Architectures properly supported ATM:
 
-* 8086
-* 8086-SSE (default)
-* ARM-VFPv2
-* ARM-VFPv2-DefaultNaN
-* RISCV
+* Linux x86-64
+* Wasm32
 
-You can specify architecture through feature like below:
+Actual feature gates:
 
-```Cargo.toml
-[dependencies.softfloat-wrapper]
-version = "0.3.3"
-default-features = false
-features = ["riscv"]
-```
+* `concordium` - Tweaks to make softfloat usable with `concordium` blockchain, where hardware floats are not supported. Disables conversions from and to platform float types (VM doesn't even have instructions for such values)
+and `F128` type. The latter is disabled due to ABI issues when building for `Wasm32`.
+Also implements traits `Serial` and `Deserial` for concordium-std.
 
 ## License
 

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -9,10 +9,12 @@ pub struct F128(float128_t);
 impl SoftFloat for F128 {
     type Payload = u128;
 
-    const EXPONENT_BIT: Self::Payload = 0x7fff;
-    const MANTISSA_BIT: Self::Payload = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff;
-    const SIGN_POS: usize = 127;
-    const EXPONENT_POS: usize = 112;
+    const MANTISSA_MASK: Self::Payload = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff;
+    const EXPONENT_MASK: Self::Payload = 0x7fff;
+    const MANTISSA_BITS: usize = 112;
+    const EXPONENT_BITS: usize = 15;
+    const EXPONENT_OFFSET: usize = 112;
+    const SIGN_OFFSET: usize = 127;
 
     #[cfg(not(feature = "concordium"))]
     fn from_native_f32(v: f32) -> Self {

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -1,4 +1,4 @@
-use crate::{SoftFloat, RoundingMode, F16, F32, F64};
+use crate::{RoundingMode, SoftFloat, F16, F32, F64};
 use softfloat_sys::float128_t;
 use std::borrow::Borrow;
 

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -6,18 +6,6 @@ use std::borrow::Borrow;
 #[derive(Copy, Clone, Debug)]
 pub struct F128(float128_t);
 
-impl F128 {
-    /// Converts primitive `f32` to `F128`
-    pub fn from_f32(v: f32) -> Self {
-        F32::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
-    }
-
-    /// Converts primitive `f64` to `F128`
-    pub fn from_f64(v: f64) -> Self {
-        F64::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
-    }
-}
-
 impl SoftFloat for F128 {
     type Payload = u128;
 
@@ -25,6 +13,16 @@ impl SoftFloat for F128 {
     const MANTISSA_BIT: Self::Payload = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff;
     const SIGN_POS: usize = 127;
     const EXPONENT_POS: usize = 112;
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f32(v: f32) -> Self {
+        F32::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
+    }
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f64(v: f64) -> Self {
+        F64::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
+    }
 
     #[inline]
     fn set_payload(&mut self, x: Self::Payload) {
@@ -348,15 +346,17 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f32() {
-        let a = F128::from_f32(0.1);
+        let a = F128::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3ffb99999a0000000000000000000000);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f64() {
-        let a = F128::from_f64(0.1);
+        let a = F128::from_native_f64(0.1);
         assert_eq!(a.to_bits(), 0x3ffb999999999999a000000000000000);
     }
 }

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F16, F32, F64};
+use crate::{SoftFloat, RoundingMode, F16, F32, F64};
 use softfloat_sys::float128_t;
 use std::borrow::Borrow;
 
@@ -18,7 +18,7 @@ impl F128 {
     }
 }
 
-impl Float for F128 {
+impl SoftFloat for F128 {
     type Payload = u128;
 
     const EXPONENT_BIT: Self::Payload = 0x7fff;

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -22,7 +22,7 @@ impl SoftFloat for F128 {
     type Payload = u128;
 
     const EXPONENT_BIT: Self::Payload = 0x7fff;
-    const FRACTION_BIT: Self::Payload = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff;
+    const MANTISSA_BIT: Self::Payload = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff;
     const SIGN_POS: usize = 127;
     const EXPONENT_POS: usize = 112;
 

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -6,21 +6,19 @@ use std::borrow::Borrow;
 #[derive(Copy, Clone, Debug)]
 pub struct F16(float16_t);
 
-impl F16 {
-    /// Converts primitive `f32` to `F16`
-    pub fn from_f32(v: f32) -> Self {
-        F32::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
-    }
-
-    /// Converts primitive `f64` to `F16`
-    pub fn from_f64(v: f64) -> Self {
-        F64::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
-    }
-}
-
 impl SoftFloat for F16 {
     type Payload = u16;
 
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f32(v: f32) -> Self {
+        F32::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
+    }
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f64(v: f64) -> Self {
+        F64::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
+    }
+    
     const EXPONENT_BIT: Self::Payload = 0x1f;
     const MANTISSA_BIT: Self::Payload = 0x3ff;
     const SIGN_POS: usize = 15;
@@ -176,7 +174,7 @@ impl SoftFloat for F16 {
         F64::from_bits(ret.v)
     }
 
-    #[cfg(feature = "f128")]
+    #[cfg(not(feature = "concordium"))]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f16_to_f128(self.0) };
@@ -344,15 +342,17 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f32() {
-        let a = F16::from_f32(0.1);
+        let a = F16::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x2e66);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f64() {
-        let a = F16::from_f64(0.1);
+        let a = F16::from_native_f64(0.1);
         assert_eq!(a.to_bits(), 0x2e66);
     }
 }

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -22,7 +22,7 @@ impl SoftFloat for F16 {
     type Payload = u16;
 
     const EXPONENT_BIT: Self::Payload = 0x1f;
-    const FRACTION_BIT: Self::Payload = 0x3ff;
+    const MANTISSA_BIT: Self::Payload = 0x3ff;
     const SIGN_POS: usize = 15;
     const EXPONENT_POS: usize = 10;
 

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -19,10 +19,12 @@ impl SoftFloat for F16 {
         F64::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
     }
     
-    const EXPONENT_BIT: Self::Payload = 0x1f;
-    const MANTISSA_BIT: Self::Payload = 0x3ff;
-    const SIGN_POS: usize = 15;
-    const EXPONENT_POS: usize = 10;
+    const MANTISSA_MASK: Self::Payload = 0x3ff;
+    const EXPONENT_MASK: Self::Payload = 0x1f;
+    const MANTISSA_BITS: usize = 10;
+    const EXPONENT_BITS: usize = 5;
+    const SIGN_OFFSET: usize = 15;
+    const EXPONENT_OFFSET: usize = 10;
 
     #[inline]
     fn set_payload(&mut self, x: Self::Payload) {

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F32, F64};
+use crate::{SoftFloat, RoundingMode, F32, F64};
 use softfloat_sys::float16_t;
 use std::borrow::Borrow;
 
@@ -18,7 +18,7 @@ impl F16 {
     }
 }
 
-impl Float for F16 {
+impl SoftFloat for F16 {
     type Payload = u16;
 
     const EXPONENT_BIT: Self::Payload = 0x1f;

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -1,4 +1,4 @@
-use crate::{SoftFloat, RoundingMode, F32, F64};
+use crate::{RoundingMode, SoftFloat, F32, F64};
 use softfloat_sys::float16_t;
 use std::borrow::Borrow;
 
@@ -18,7 +18,7 @@ impl SoftFloat for F16 {
     fn from_native_f64(v: f64) -> Self {
         F64::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
     }
-    
+
     const MANTISSA_MASK: Self::Payload = 0x3ff;
     const EXPONENT_MASK: Self::Payload = 0x1f;
     const MANTISSA_BITS: usize = 10;

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F128, F32, F64};
+use crate::{Float, RoundingMode, F32, F64};
 use softfloat_sys::float16_t;
 use std::borrow::Borrow;
 
@@ -176,13 +176,14 @@ impl Float for F16 {
         F64::from_bits(ret.v)
     }
 
-    fn to_f128(&self, rnd: RoundingMode) -> F128 {
+    #[cfg(feature = "f128")]
+    fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f16_to_f128(self.0) };
         let mut v = 0u128;
         v |= ret.v[0] as u128;
         v |= (ret.v[1] as u128) << 64;
-        F128::from_bits(v)
+        super::F128::from_bits(v)
     }
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F16, F64};
+use crate::{SoftFloat, RoundingMode, F16, F64};
 use softfloat_sys::float32_t;
 use std::borrow::Borrow;
 
@@ -18,7 +18,7 @@ impl F32 {
     }
 }
 
-impl Float for F32 {
+impl SoftFloat for F32 {
     type Payload = u32;
 
     const EXPONENT_BIT: Self::Payload = 0xff;

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -1,4 +1,4 @@
-use crate::{SoftFloat, RoundingMode, F16, F64};
+use crate::{RoundingMode, SoftFloat, F16, F64};
 use softfloat_sys::float32_t;
 use std::borrow::Borrow;
 
@@ -6,8 +6,7 @@ use std::borrow::Borrow;
 #[derive(Copy, Clone, Debug)]
 pub struct F32(float32_t);
 
-impl F32 {
-}
+impl F32 {}
 
 impl SoftFloat for F32 {
     type Payload = u32;

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F128, F16, F64};
+use crate::{Float, RoundingMode, F16, F64};
 use softfloat_sys::float32_t;
 use std::borrow::Borrow;
 
@@ -176,13 +176,14 @@ impl Float for F32 {
         F64::from_bits(ret.v)
     }
 
-    fn to_f128(&self, rnd: RoundingMode) -> F128 {
+    #[cfg(feature = "f128")]
+    fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f32_to_f128(self.0) };
         let mut v = 0u128;
         v |= ret.v[0] as u128;
         v |= (ret.v[1] as u128) << 64;
-        F128::from_bits(v)
+        super::F128::from_bits(v)
     }
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -7,15 +7,6 @@ use std::borrow::Borrow;
 pub struct F32(float32_t);
 
 impl F32 {
-    /// Converts primitive `f32` to `F32`
-    pub fn from_f32(v: f32) -> Self {
-        Self::from_bits(v.to_bits())
-    }
-
-    /// Converts primitive `f64` to `F32`
-    pub fn from_f64(v: f64) -> Self {
-        F64::from_bits(v.to_bits()).to_f32(RoundingMode::TiesToEven)
-    }
 }
 
 impl SoftFloat for F32 {
@@ -25,6 +16,16 @@ impl SoftFloat for F32 {
     const MANTISSA_BIT: Self::Payload = 0x7f_ffff;
     const SIGN_POS: usize = 31;
     const EXPONENT_POS: usize = 23;
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f32(v: f32) -> Self {
+        Self::from_bits(v.to_bits())
+    }
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f64(v: f64) -> Self {
+        F64::from_bits(v.to_bits()).to_f32(RoundingMode::TiesToEven)
+    }
 
     #[inline]
     fn set_payload(&mut self, x: Self::Payload) {
@@ -176,7 +177,7 @@ impl SoftFloat for F32 {
         F64::from_bits(ret.v)
     }
 
-    #[cfg(feature = "f128")]
+    #[cfg(not(feature = "concordium"))]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f32_to_f128(self.0) };
@@ -344,15 +345,17 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f32() {
-        let a = F32::from_f32(0.1);
+        let a = F32::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3dcccccd);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f64() {
-        let a = F32::from_f64(0.1);
+        let a = F32::from_native_f64(0.1);
         assert_eq!(a.to_bits(), 0x3dcccccd);
     }
 }

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -12,10 +12,12 @@ impl F32 {
 impl SoftFloat for F32 {
     type Payload = u32;
 
-    const EXPONENT_BIT: Self::Payload = 0xff;
-    const MANTISSA_BIT: Self::Payload = 0x7f_ffff;
-    const SIGN_POS: usize = 31;
-    const EXPONENT_POS: usize = 23;
+    const MANTISSA_MASK: Self::Payload = 0x7f_ffff;
+    const EXPONENT_MASK: Self::Payload = 0xff;
+    const MANTISSA_BITS: usize = 23;
+    const EXPONENT_BITS: usize = 8;
+    const SIGN_OFFSET: usize = 31;
+    const EXPONENT_OFFSET: usize = 23;
 
     #[cfg(not(feature = "concordium"))]
     fn from_native_f32(v: f32) -> Self {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -22,7 +22,7 @@ impl SoftFloat for F32 {
     type Payload = u32;
 
     const EXPONENT_BIT: Self::Payload = 0xff;
-    const FRACTION_BIT: Self::Payload = 0x7f_ffff;
+    const MANTISSA_BIT: Self::Payload = 0x7f_ffff;
     const SIGN_POS: usize = 31;
     const EXPONENT_POS: usize = 23;
 

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -1,4 +1,4 @@
-use crate::{SoftFloat, RoundingMode, F16, F32, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE};
+use crate::{SoftFloat, RoundingMode, F16, F32, DEFAULT_ROUNDING_MODE};
 use num_traits::One;
 use softfloat_sys::float64_t;
 use std::{borrow::Borrow, ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign, Rem, RemAssign, Neg}};
@@ -133,152 +133,15 @@ impl PartialOrd for F64 {
     }
 }
 
-#[cfg(not(feature = "concordium"))]
-impl From<f32> for F64 {
-    fn from(value: f32) -> Self {
-        F64::from_native_f32(value)
-    }
-}
-
-#[cfg(not(feature = "concordium"))]
-impl From<f64> for F64 {
-    fn from(value: f64) -> Self {
-        F64::from_native_f64(value)
-    }
-}
-
-impl From<i8> for F64 {
-    fn from(value: i8) -> Self {
-        SoftFloat::from_i8(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<i16> for F64 {
-    fn from(value: i16) -> Self {
-        SoftFloat::from_i16(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<i32> for F64 {
-    fn from(value: i32) -> Self {
-        SoftFloat::from_i32(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<i64> for F64 {
-    fn from(value: i64) -> Self {
-        SoftFloat::from_i64(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<i128> for F64 {
-    fn from(value: i128) -> Self {
-        // FIXME: need proper implementation
-        SoftFloat::from_i64(value as i64, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<u8> for F64 {
-    fn from(value: u8) -> Self {
-        SoftFloat::from_u8(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<u16> for F64 {
-    fn from(value: u16) -> Self {
-        SoftFloat::from_u16(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<u32> for F64 {
-    fn from(value: u32) -> Self {
-        SoftFloat::from_u32(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<u64> for F64 {
-    fn from(value: u64) -> Self {
-        SoftFloat::from_u64(value, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<u128> for F64 {
-    fn from(value: u128) -> Self {
-        // FIXME: need proper implementation
-        SoftFloat::from_u64(value as u64, DEFAULT_ROUNDING_MODE)
-    }
-}
-
-impl From<F64> for i128 {
-    fn from(value: F64) -> Self {
-        // FIXME: need proper implementation
-        SoftFloat::to_i64(&value, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE) as i128
-    }
-}
-
-impl From<F64> for u128 {
-    fn from(value: F64) -> Self {
-        // FIXME: need proper implementation
-        SoftFloat::to_u64(&value, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE) as u128
-    }
-}
-
-impl num_traits::Num for F64 {
-    type FromStrRadixErr = ();
-
-    fn from_str_radix(_str: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
-        unimplemented!()
-    }
-}
-
-impl num_traits::Signed for F64 {
-    fn abs(&self) -> Self {
-        SoftFloat::abs(&self)
-    }
-
-    fn abs_sub(&self, other: &Self) -> Self {
-        let result = *self - *other;
-        if SoftFloat::is_positive(self) {
-            result
-        }
-        else {
-            num_traits::Zero::zero()
-        }
-    }
-
-    fn signum(&self) -> Self {
-        if SoftFloat::is_nan(self) {
-            SoftFloat::quiet_nan()
-        }
-        else if SoftFloat::is_negative(self) {
-            -Self::one()
-        }
-        else {
-            Self::one()
-        }
-    }
-
-    fn is_positive(&self) -> bool {
-        !SoftFloat::is_zero(self)
-        && SoftFloat::is_positive(self)
-    }
-
-    fn is_negative(&self) -> bool {
-        !SoftFloat::is_zero(self)
-        && SoftFloat::is_negative(self)
-    }
-}
-// `num_traits::Float` requires trigonometry and some other funcs,
-// so it's used only as guiding trait here
-// impl num_traits::Float for F64 {}
-
 impl SoftFloat for F64 {
     type Payload = u64;
 
-    const EXPONENT_BIT: Self::Payload = 0x7ff;
-    const MANTISSA_BIT: Self::Payload = 0xf_ffff_ffff_ffff;
-    const SIGN_POS: usize = 63;
-    const EXPONENT_POS: usize = 52;
+    const MANTISSA_MASK: Self::Payload = 0xf_ffff_ffff_ffff;
+    const EXPONENT_MASK: Self::Payload = 0x7ff;
+    const MANTISSA_BITS: usize = 52;
+    const EXPONENT_BITS: usize = 11;
+    const SIGN_OFFSET: usize = 63;
+    const EXPONENT_OFFSET: usize = 52;
 
     #[cfg(not(feature = "concordium"))]
     fn from_native_f32(v: f32) -> Self {

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F16, F32};
+use crate::{SoftFloat, RoundingMode, F16, F32};
 use softfloat_sys::float64_t;
 use std::borrow::Borrow;
 
@@ -18,7 +18,7 @@ impl F64 {
     }
 }
 
-impl Float for F64 {
+impl SoftFloat for F64 {
     type Payload = u64;
 
     const EXPONENT_BIT: Self::Payload = 0x7ff;

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -22,7 +22,7 @@ impl SoftFloat for F64 {
     type Payload = u64;
 
     const EXPONENT_BIT: Self::Payload = 0x7ff;
-    const FRACTION_BIT: Self::Payload = 0xf_ffff_ffff_ffff;
+    const MANTISSA_BIT: Self::Payload = 0xf_ffff_ffff_ffff;
     const SIGN_POS: usize = 63;
     const EXPONENT_POS: usize = 52;
 

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -6,18 +6,6 @@ use std::borrow::Borrow;
 #[derive(Copy, Clone, Debug)]
 pub struct F64(float64_t);
 
-impl F64 {
-    /// Converts primitive `f32` to `F64`
-    pub fn from_f32(v: f32) -> Self {
-        F32::from_bits(v.to_bits()).to_f64(RoundingMode::TiesToEven)
-    }
-
-    /// Converts primitive `f64` to `F64`
-    pub fn from_f64(v: f64) -> Self {
-        Self::from_bits(v.to_bits())
-    }
-}
-
 impl SoftFloat for F64 {
     type Payload = u64;
 
@@ -25,6 +13,16 @@ impl SoftFloat for F64 {
     const MANTISSA_BIT: Self::Payload = 0xf_ffff_ffff_ffff;
     const SIGN_POS: usize = 63;
     const EXPONENT_POS: usize = 52;
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f32(v: f32) -> Self {
+        F32::from_bits(v.to_bits()).to_f64(RoundingMode::TiesToEven)
+    }
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f64(v: f64) -> Self {
+        Self::from_bits(v.to_bits())
+    }
 
     #[inline]
     fn set_payload(&mut self, x: Self::Payload) {
@@ -176,7 +174,7 @@ impl SoftFloat for F64 {
         Self::from_bits(self.to_bits())
     }
 
-    #[cfg(feature = "f128")]
+    #[cfg(not(feature = "concordium"))]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f64_to_f128(self.0) };
@@ -344,15 +342,17 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f32() {
-        let a = F64::from_f32(0.1);
+        let a = F64::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3fb99999a0000000);
     }
 
+    #[cfg(not(feature = "concordium"))]
     #[test]
     fn from_f64() {
-        let a = F64::from_f64(0.1);
+        let a = F64::from_native_f64(0.1);
         assert_eq!(a.to_bits(), 0x3fb999999999999a);
     }
 }

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -1,7 +1,10 @@
-use crate::{SoftFloat, RoundingMode, F16, F32, DEFAULT_ROUNDING_MODE};
+use crate::{RoundingMode, SoftFloat, DEFAULT_ROUNDING_MODE, F16, F32};
 use num_traits::One;
 use softfloat_sys::float64_t;
-use std::{borrow::Borrow, ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign, Rem, RemAssign, Neg}};
+use std::{
+    borrow::Borrow,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
+};
 
 /// standard 64-bit float
 #[derive(Copy, Clone, Debug)]

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -1,10 +1,276 @@
-use crate::{SoftFloat, RoundingMode, F16, F32};
+use crate::{SoftFloat, RoundingMode, F16, F32, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE};
+use num_traits::One;
 use softfloat_sys::float64_t;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, ops::{Add, AddAssign, Sub, SubAssign, Mul, MulAssign, Div, DivAssign, Rem, RemAssign, Neg}};
 
 /// standard 64-bit float
 #[derive(Copy, Clone, Debug)]
 pub struct F64(float64_t);
+
+#[cfg(feature = "concordium")]
+impl concordium_std::Serial for F64 {
+    fn serial<W: concordium_std::Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        self.to_bits().serial(out)
+    }
+}
+
+#[cfg(feature = "concordium")]
+impl concordium_std::Deserial for F64 {
+    fn deserial<R: concordium_std::Read>(source: &mut R) -> concordium_std::ParseResult<Self> {
+        Ok(F64::from_bits(u64::deserial(source)?))
+    }
+}
+
+impl Default for F64 {
+    fn default() -> Self {
+        num_traits::Zero::zero()
+    }
+}
+
+impl num_traits::Zero for F64 {
+    fn zero() -> Self {
+        SoftFloat::positive_zero()
+    }
+
+    fn is_zero(&self) -> bool {
+        SoftFloat::is_zero(self)
+    }
+}
+
+impl One for F64 {
+    fn one() -> Self {
+        SoftFloat::from_i8(1, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl Neg for F64 {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        SoftFloat::neg(&self)
+    }
+}
+
+impl Add for F64 {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        SoftFloat::add(&self, rhs, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl AddAssign for F64 {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for F64 {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        SoftFloat::sub(&self, rhs, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl SubAssign for F64 {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Mul for F64 {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        SoftFloat::mul(&self, rhs, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl MulAssign for F64 {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl Div for F64 {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        SoftFloat::div(&self, rhs, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl DivAssign for F64 {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl Rem for F64 {
+    type Output = Self;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        SoftFloat::rem(&self, rhs, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl RemAssign for F64 {
+    fn rem_assign(&mut self, rhs: Self) {
+        *self = *self % rhs;
+    }
+}
+
+impl PartialEq for F64 {
+    fn eq(&self, other: &Self) -> bool {
+        SoftFloat::eq(self, other)
+    }
+}
+
+impl PartialOrd for F64 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        SoftFloat::compare(self, other)
+    }
+}
+
+#[cfg(not(feature = "concordium"))]
+impl From<f32> for F64 {
+    fn from(value: f32) -> Self {
+        F64::from_native_f32(value)
+    }
+}
+
+#[cfg(not(feature = "concordium"))]
+impl From<f64> for F64 {
+    fn from(value: f64) -> Self {
+        F64::from_native_f64(value)
+    }
+}
+
+impl From<i8> for F64 {
+    fn from(value: i8) -> Self {
+        SoftFloat::from_i8(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<i16> for F64 {
+    fn from(value: i16) -> Self {
+        SoftFloat::from_i16(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<i32> for F64 {
+    fn from(value: i32) -> Self {
+        SoftFloat::from_i32(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<i64> for F64 {
+    fn from(value: i64) -> Self {
+        SoftFloat::from_i64(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<i128> for F64 {
+    fn from(value: i128) -> Self {
+        // FIXME: need proper implementation
+        SoftFloat::from_i64(value as i64, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<u8> for F64 {
+    fn from(value: u8) -> Self {
+        SoftFloat::from_u8(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<u16> for F64 {
+    fn from(value: u16) -> Self {
+        SoftFloat::from_u16(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<u32> for F64 {
+    fn from(value: u32) -> Self {
+        SoftFloat::from_u32(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<u64> for F64 {
+    fn from(value: u64) -> Self {
+        SoftFloat::from_u64(value, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<u128> for F64 {
+    fn from(value: u128) -> Self {
+        // FIXME: need proper implementation
+        SoftFloat::from_u64(value as u64, DEFAULT_ROUNDING_MODE)
+    }
+}
+
+impl From<F64> for i128 {
+    fn from(value: F64) -> Self {
+        // FIXME: need proper implementation
+        SoftFloat::to_i64(&value, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE) as i128
+    }
+}
+
+impl From<F64> for u128 {
+    fn from(value: F64) -> Self {
+        // FIXME: need proper implementation
+        SoftFloat::to_u64(&value, DEFAULT_ROUNDING_MODE, DEFAULT_EXACT_MODE) as u128
+    }
+}
+
+impl num_traits::Num for F64 {
+    type FromStrRadixErr = ();
+
+    fn from_str_radix(_str: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        unimplemented!()
+    }
+}
+
+impl num_traits::Signed for F64 {
+    fn abs(&self) -> Self {
+        SoftFloat::abs(&self)
+    }
+
+    fn abs_sub(&self, other: &Self) -> Self {
+        let result = *self - *other;
+        if SoftFloat::is_positive(self) {
+            result
+        }
+        else {
+            num_traits::Zero::zero()
+        }
+    }
+
+    fn signum(&self) -> Self {
+        if SoftFloat::is_nan(self) {
+            SoftFloat::quiet_nan()
+        }
+        else if SoftFloat::is_negative(self) {
+            -Self::one()
+        }
+        else {
+            Self::one()
+        }
+    }
+
+    fn is_positive(&self) -> bool {
+        !SoftFloat::is_zero(self)
+        && SoftFloat::is_positive(self)
+    }
+
+    fn is_negative(&self) -> bool {
+        !SoftFloat::is_zero(self)
+        && SoftFloat::is_negative(self)
+    }
+}
+// `num_traits::Float` requires trigonometry and some other funcs,
+// so it's used only as guiding trait here
+// impl num_traits::Float for F64 {}
 
 impl SoftFloat for F64 {
     type Payload = u64;
@@ -202,7 +468,7 @@ mod tests {
         let b = 0x76546410aaaaaaaa;
         let a0 = F64::from_bits(a);
         let b0 = F64::from_bits(b);
-        let d0 = a0.add(b0, RoundingMode::TiesToEven);
+        let d0 = SoftFloat::add(&a0, b0, RoundingMode::TiesToEven);
         let a1 = simple_soft_float::F64::from_bits(a);
         let b1 = simple_soft_float::F64::from_bits(b);
         let d1 = a1.add(&b1, Some(simple_soft_float::RoundingMode::TiesToEven), None);
@@ -215,7 +481,7 @@ mod tests {
         let b = 0x76546410aaaaaaaa;
         let a0 = F64::from_bits(a);
         let b0 = F64::from_bits(b);
-        let d0 = a0.sub(b0, RoundingMode::TiesToEven);
+        let d0 = SoftFloat::sub(&a0, b0, RoundingMode::TiesToEven);
         let a1 = simple_soft_float::F64::from_bits(a);
         let b1 = simple_soft_float::F64::from_bits(b);
         let d1 = a1.sub(&b1, Some(simple_soft_float::RoundingMode::TiesToEven), None);
@@ -228,7 +494,7 @@ mod tests {
         let b = 0x76546410aaaaaaaa;
         let a0 = F64::from_bits(a);
         let b0 = F64::from_bits(b);
-        let d0 = a0.mul(b0, RoundingMode::TiesToEven);
+        let d0 = SoftFloat::mul(&a0, b0, RoundingMode::TiesToEven);
         let a1 = simple_soft_float::F64::from_bits(a);
         let b1 = simple_soft_float::F64::from_bits(b);
         let d1 = a1.mul(&b1, Some(simple_soft_float::RoundingMode::TiesToEven), None);
@@ -262,7 +528,7 @@ mod tests {
         let b = 0x12346410aaaaaaaa;
         let a0 = F64::from_bits(a);
         let b0 = F64::from_bits(b);
-        let d0 = a0.div(b0, RoundingMode::TiesToEven);
+        let d0 = SoftFloat::div(&a0, b0, RoundingMode::TiesToEven);
         let a1 = simple_soft_float::F64::from_bits(a);
         let b1 = simple_soft_float::F64::from_bits(b);
         let d1 = a1.div(&b1, Some(simple_soft_float::RoundingMode::TiesToEven), None);
@@ -275,7 +541,7 @@ mod tests {
         let b = 0x12346410aaaaaaaa;
         let a0 = F64::from_bits(a);
         let b0 = F64::from_bits(b);
-        let d0 = a0.rem(b0, RoundingMode::TiesToEven);
+        let d0 = SoftFloat::rem(&a0, b0, RoundingMode::TiesToEven);
         let a1 = simple_soft_float::F64::from_bits(a);
         let b1 = simple_soft_float::F64::from_bits(b);
         let d1 = a1.ieee754_remainder(&b1, Some(simple_soft_float::RoundingMode::TiesToEven), None);
@@ -319,13 +585,13 @@ mod tests {
 
         let mut flag = ExceptionFlags::default();
         flag.set();
-        assert_eq!(a.eq(a), false);
+        assert_eq!(a == a, false);
         flag.get();
         assert_eq!(flag.is_invalid(), true);
 
         let mut flag = ExceptionFlags::default();
         flag.set();
-        assert_eq!(b.eq(b), false);
+        assert_eq!(b == b, false);
         flag.get();
         assert_eq!(flag.is_invalid(), false);
 

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -1,4 +1,4 @@
-use crate::{Float, RoundingMode, F128, F16, F32};
+use crate::{Float, RoundingMode, F16, F32};
 use softfloat_sys::float64_t;
 use std::borrow::Borrow;
 
@@ -176,13 +176,14 @@ impl Float for F64 {
         Self::from_bits(self.to_bits())
     }
 
-    fn to_f128(&self, rnd: RoundingMode) -> F128 {
+    #[cfg(feature = "f128")]
+    fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f64_to_f128(self.0) };
         let mut v = 0u128;
         v |= ret.v[0] as u128;
         v |= (ret.v[1] as u128) << 64;
-        F128::from_bits(v)
+        super::F128::from_bits(v)
     }
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,12 @@
 //! }
 //! ```
 
-#[cfg(feature = "f128")]
+#[cfg(not(feature = "concordium"))]
 mod f128;
 mod f16;
 mod f32;
 mod f64;
-#[cfg(feature = "f128")]
+#[cfg(not(feature = "concordium"))]
 pub use crate::f128::F128;
 pub use crate::f16::F16;
 pub use crate::f32::F32;
@@ -173,6 +173,12 @@ pub trait SoftFloat {
     const SIGN_POS: usize;
     const EXPONENT_POS: usize;
 
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f32(value: f32) -> Self;
+
+    #[cfg(not(feature = "concordium"))]
+    fn from_native_f64(value: f64) -> Self;
+
     fn set_payload(&mut self, x: Self::Payload);
 
     fn from_bits(v: Self::Payload) -> Self;
@@ -232,7 +238,7 @@ pub trait SoftFloat {
 
     fn to_f64(&self, rnd: RoundingMode) -> F64;
 
-    #[cfg(feature = "f128")]
+    #[cfg(not(feature = "concordium"))]
     fn to_f128(&self, rnd: RoundingMode) -> F128;
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{LowerHex, UpperHex};
 
+pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::TiesToEven;
+pub const DEFAULT_EXACT_MODE: bool = true;
+
 /// floating-point rounding mode defined by standard
 #[derive(Copy, Clone, Debug)]
 pub enum RoundingMode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub trait SoftFloat {
     type Payload: PrimInt + UpperHex + LowerHex;
 
     const EXPONENT_BIT: Self::Payload;
-    const FRACTION_BIT: Self::Payload;
+    const MANTISSA_BIT: Self::Payload;
     const SIGN_POS: usize;
     const EXPONENT_POS: usize;
 
@@ -315,8 +315,8 @@ pub trait SoftFloat {
     }
 
     #[inline]
-    fn fraction(&self) -> Self::Payload {
-        self.to_bits() & Self::FRACTION_BIT
+    fn mantissa(&self) -> Self::Payload {
+        self.to_bits() & Self::MANTISSA_BIT
     }
 
     #[inline]
@@ -328,14 +328,14 @@ pub trait SoftFloat {
     fn is_positive_zero(&self) -> bool {
         self.is_positive()
             && self.exponent() == Self::Payload::zero()
-            && self.fraction() == Self::Payload::zero()
+            && self.mantissa() == Self::Payload::zero()
     }
 
     #[inline]
     fn is_positive_subnormal(&self) -> bool {
         self.is_positive()
             && self.exponent() == Self::Payload::zero()
-            && self.fraction() != Self::Payload::zero()
+            && self.mantissa() != Self::Payload::zero()
     }
 
     #[inline]
@@ -349,7 +349,7 @@ pub trait SoftFloat {
     fn is_positive_infinity(&self) -> bool {
         self.is_positive()
             && self.exponent() == Self::EXPONENT_BIT
-            && self.fraction() == Self::Payload::zero()
+            && self.mantissa() == Self::Payload::zero()
     }
 
     #[inline]
@@ -361,14 +361,14 @@ pub trait SoftFloat {
     fn is_negative_zero(&self) -> bool {
         self.is_negative()
             && self.exponent() == Self::Payload::zero()
-            && self.fraction() == Self::Payload::zero()
+            && self.mantissa() == Self::Payload::zero()
     }
 
     #[inline]
     fn is_negative_subnormal(&self) -> bool {
         self.is_negative()
             && self.exponent() == Self::Payload::zero()
-            && self.fraction() != Self::Payload::zero()
+            && self.mantissa() != Self::Payload::zero()
     }
 
     #[inline]
@@ -382,12 +382,12 @@ pub trait SoftFloat {
     fn is_negative_infinity(&self) -> bool {
         self.is_negative()
             && self.exponent() == Self::EXPONENT_BIT
-            && self.fraction() == Self::Payload::zero()
+            && self.mantissa() == Self::Payload::zero()
     }
 
     #[inline]
     fn is_nan(&self) -> bool {
-        self.exponent() == Self::EXPONENT_BIT && self.fraction() != Self::Payload::zero()
+        self.exponent() == Self::EXPONENT_BIT && self.mantissa() != Self::Payload::zero()
     }
 
     #[inline]
@@ -417,8 +417,8 @@ pub trait SoftFloat {
     }
 
     #[inline]
-    fn set_fraction(&mut self, x: Self::Payload) {
-        self.set_payload((self.to_bits() & !Self::FRACTION_BIT) | (x & Self::FRACTION_BIT));
+    fn set_mantissa(&mut self, x: Self::Payload) {
+        self.set_payload((self.to_bits() & !Self::MANTISSA_BIT) | (x & Self::MANTISSA_BIT));
     }
 
     #[inline]
@@ -468,7 +468,7 @@ pub trait SoftFloat {
     {
         let mut x = Self::from_bits(Self::Payload::zero());
         x.set_exponent(Self::EXPONENT_BIT);
-        x.set_fraction(Self::Payload::one() << (Self::EXPONENT_POS - 1));
+        x.set_mantissa(Self::Payload::one() << (Self::EXPONENT_POS - 1));
         x
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{LowerHex, UpperHex};
 
-pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::TiesToEven;
+pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::TiesToAway;
 pub const DEFAULT_EXACT_MODE: bool = true;
 
 /// floating-point rounding mode defined by standard

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Examples
 //!
 //! ```
-//! use softfloat_wrapper::{Float, F16, RoundingMode};
+//! use softfloat_wrapper::{SoftFloat, F16, RoundingMode};
 //!
 //! fn main() {
 //!     let a = 0x1234;
@@ -81,7 +81,7 @@ impl RoundingMode {
 /// ## Examples
 ///
 /// ```
-/// use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F16};
+/// use softfloat_wrapper::{ExceptionFlags, SoftFloat, RoundingMode, F16};
 ///
 /// let a = 0x0;
 /// let b = 0x0;
@@ -155,9 +155,9 @@ impl ExceptionFlags {
 /// `Float` can be used for generic functions.
 ///
 /// ```
-/// use softfloat_wrapper::{Float, RoundingMode, F16, F32};
+/// use softfloat_wrapper::{SoftFloat, RoundingMode, F16, F32};
 ///
-/// fn rsqrt<T: Float>(x: T) -> T {
+/// fn rsqrt<T: SoftFloat>(x: T) -> T {
 ///     let ret = x.sqrt(RoundingMode::TiesToEven);
 ///     let one = T::from_u8(1, RoundingMode::TiesToEven);
 ///     one.div(ret, RoundingMode::TiesToEven)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ impl ExceptionFlags {
 /// let a = F32::from_bits(0x12345678);
 /// let a = rsqrt(a);
 /// ```
-pub trait Float {
+pub trait SoftFloat {
     type Payload: PrimInt + UpperHex + LowerHex;
 
     const EXPONENT_BIT: Self::Payload;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,12 @@
 //! }
 //! ```
 
+#[cfg(feature = "f128")]
 mod f128;
 mod f16;
 mod f32;
 mod f64;
+#[cfg(feature = "f128")]
 pub use crate::f128::F128;
 pub use crate::f16::F16;
 pub use crate::f32::F32;
@@ -230,6 +232,7 @@ pub trait Float {
 
     fn to_f64(&self, rnd: RoundingMode) -> F64;
 
+    #[cfg(feature = "f128")]
     fn to_f128(&self, rnd: RoundingMode) -> F128;
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self;


### PR DESCRIPTION
Additional adjustments:
* Concordium-specific features
* Implemented standard operation traits for `F64`