### PR TITLE
Reduce dependencies, make more streamlined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softfloat-wrapper"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["dalance@gmail.com"]
 repository = "https://github.com/dalance/softfloat-wrapper"
 keywords = ["softfloat"]
@@ -8,19 +8,16 @@ categories = ["api-bindings", "mathematics"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "a safe wrapper of Berkeley SoftFloat based on softfloat-sys"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-concordium = ["dep:concordium-std"]
+native-float = []
+f128 = []
 
 [dependencies]
 num-traits = "0.2.12"
-
-[dependencies.concordium-std]
-version = "4.0"
-optional = true
 
 [dependencies.softfloat-sys]
 git = "https://github.com/tacanslabs/softfloat-sys.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+# Enables conversion from and into native float types
 native-float = []
+# Enables soft F128 type
 f128 = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ Architectures properly supported ATM:
 
 Actual feature gates:
 
-* `concordium` - Tweaks to make softfloat usable with `concordium` blockchain, where hardware floats are not supported. Disables conversions from and to platform float types (VM doesn't even have instructions for such values)
-and `F128` type. The latter is disabled due to ABI issues when building for `Wasm32`.
-Also implements traits `Serial` and `Deserial` for concordium-std.
+* `native-float` - enables conversions from and to native floating-point types
+* `f128` - enables quad-precision `F128` type
 
 ## License
 

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -4,7 +4,21 @@ use std::borrow::Borrow;
 
 /// standard 128-bit float
 #[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
 pub struct F128(float128_t);
+
+impl F128 {
+    pub const fn from_bits(v: u128) -> Self {
+        Self(float128_t { v: [v as u64, (v >> 64) as u64] })
+    }
+
+    pub const fn to_bits(&self) -> u128 {
+        let mut ret = 0u128;
+        ret |= self.0.v[0] as u128;
+        ret |= (self.0.v[1] as u128) << 64;
+        ret
+    }
+}
 
 impl SoftFloat for F128 {
     type Payload = u128;
@@ -34,16 +48,12 @@ impl SoftFloat for F128 {
 
     #[inline]
     fn from_bits(v: Self::Payload) -> Self {
-        let v = [v as u64, (v >> 64) as u64];
-        Self(float128_t { v })
+        F128::from_bits(v)
     }
 
     #[inline]
     fn to_bits(&self) -> Self::Payload {
-        let mut ret = 0u128;
-        ret |= self.0.v[0] as u128;
-        ret |= (self.0.v[1] as u128) << 64;
-        ret
+        F128::to_bits(self)
     }
 
     #[inline]

--- a/src/f128.rs
+++ b/src/f128.rs
@@ -16,12 +16,12 @@ impl SoftFloat for F128 {
     const EXPONENT_OFFSET: usize = 112;
     const SIGN_OFFSET: usize = 127;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f32(v: f32) -> Self {
         F32::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f64(v: f64) -> Self {
         F64::from_bits(v.to_bits()).to_f128(RoundingMode::TiesToEven)
     }
@@ -348,14 +348,14 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f32() {
         let a = F128::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3ffb99999a0000000000000000000000);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f64() {
         let a = F128::from_native_f64(0.1);

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -4,7 +4,18 @@ use std::borrow::Borrow;
 
 /// standard 16-bit float
 #[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
 pub struct F16(float16_t);
+
+impl F16 {
+    pub const fn from_bits(v: u16) -> Self {
+        Self(float16_t { v })
+    }
+
+    pub const fn to_bits(&self) -> u16 {
+        self.0.v
+    }
+}
 
 impl SoftFloat for F16 {
     type Payload = u16;
@@ -33,12 +44,12 @@ impl SoftFloat for F16 {
 
     #[inline]
     fn from_bits(v: Self::Payload) -> Self {
-        Self(float16_t { v })
+        F16::from_bits(v)
     }
 
     #[inline]
     fn to_bits(&self) -> Self::Payload {
-        self.0.v
+        F16::to_bits(self)
     }
 
     #[inline]

--- a/src/f16.rs
+++ b/src/f16.rs
@@ -9,12 +9,12 @@ pub struct F16(float16_t);
 impl SoftFloat for F16 {
     type Payload = u16;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f32(v: f32) -> Self {
         F32::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f64(v: f64) -> Self {
         F64::from_bits(v.to_bits()).to_f16(RoundingMode::TiesToEven)
     }
@@ -176,7 +176,7 @@ impl SoftFloat for F16 {
         F64::from_bits(ret.v)
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "f128")]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f16_to_f128(self.0) };
@@ -344,14 +344,14 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f32() {
         let a = F16::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x2e66);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f64() {
         let a = F16::from_native_f64(0.1);

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -4,7 +4,18 @@ use std::borrow::Borrow;
 
 /// standard 32-bit float
 #[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
 pub struct F32(float32_t);
+
+impl F32 {
+    pub const fn from_bits(v: u32) -> Self {
+        Self(float32_t { v })
+    }
+
+    pub const fn to_bits(&self) -> u32 {
+        self.0.v
+    }
+}
 
 impl SoftFloat for F32 {
     type Payload = u32;
@@ -33,12 +44,12 @@ impl SoftFloat for F32 {
 
     #[inline]
     fn from_bits(v: Self::Payload) -> Self {
-        Self(float32_t { v })
+        F32::from_bits(v)
     }
 
     #[inline]
     fn to_bits(&self) -> Self::Payload {
-        self.0.v
+        F32::to_bits(self)
     }
 
     #[inline]

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -16,12 +16,12 @@ impl SoftFloat for F32 {
     const SIGN_OFFSET: usize = 31;
     const EXPONENT_OFFSET: usize = 23;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f32(v: f32) -> Self {
         Self::from_bits(v.to_bits())
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f64(v: f64) -> Self {
         F64::from_bits(v.to_bits()).to_f32(RoundingMode::TiesToEven)
     }
@@ -176,7 +176,7 @@ impl SoftFloat for F32 {
         F64::from_bits(ret.v)
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "f128")]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f32_to_f128(self.0) };
@@ -344,14 +344,14 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f32() {
         let a = F32::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3dcccccd);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f64() {
         let a = F32::from_native_f64(0.1);

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -4,7 +4,18 @@ use std::borrow::Borrow;
 
 /// standard 64-bit float
 #[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
 pub struct F64(float64_t);
+
+impl F64 {
+    pub const fn from_bits(v: u64) -> Self {
+        Self(float64_t { v })
+    }
+
+    pub const fn to_bits(&self) -> u64 {
+        self.0.v
+    }
+}
 
 impl SoftFloat for F64 {
     type Payload = u64;
@@ -33,12 +44,12 @@ impl SoftFloat for F64 {
 
     #[inline]
     fn from_bits(v: Self::Payload) -> Self {
-        Self(float64_t { v })
+        F64::from_bits(v)
     }
 
     #[inline]
     fn to_bits(&self) -> Self::Payload {
-        self.0.v
+        F64::to_bits(self)
     }
 
     #[inline]

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -321,13 +321,13 @@ mod tests {
 
         let mut flag = ExceptionFlags::default();
         flag.set();
-        assert_eq!(a == a, false);
+        assert_eq!(a.eq(a), false);
         flag.get();
         assert_eq!(flag.is_invalid(), true);
 
         let mut flag = ExceptionFlags::default();
         flag.set();
-        assert_eq!(b == b, false);
+        assert_eq!(b.eq(b), false);
         flag.get();
         assert_eq!(flag.is_invalid(), false);
 

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -16,12 +16,12 @@ impl SoftFloat for F64 {
     const SIGN_OFFSET: usize = 63;
     const EXPONENT_OFFSET: usize = 52;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f32(v: f32) -> Self {
         F32::from_bits(v.to_bits()).to_f64(RoundingMode::TiesToEven)
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f64(v: f64) -> Self {
         Self::from_bits(v.to_bits())
     }
@@ -176,7 +176,7 @@ impl SoftFloat for F64 {
         Self::from_bits(self.to_bits())
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "f128")]
     fn to_f128(&self, rnd: RoundingMode) -> super::F128 {
         rnd.set();
         let ret = unsafe { softfloat_sys::f64_to_f128(self.0) };
@@ -344,14 +344,14 @@ mod tests {
         assert_eq!(flag.is_invalid(), true);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f32() {
         let a = F64::from_native_f32(0.1);
         assert_eq!(a.to_bits(), 0x3fb99999a0000000);
     }
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     #[test]
     fn from_f64() {
         let a = F64::from_native_f64(0.1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,6 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{LowerHex, UpperHex};
 
-pub const DEFAULT_ROUNDING_MODE: RoundingMode = RoundingMode::TiesToAway;
-pub const DEFAULT_EXACT_MODE: bool = true;
-
 /// floating-point rounding mode defined by standard
 #[derive(Copy, Clone, Debug)]
 pub enum RoundingMode {
@@ -489,128 +486,6 @@ pub trait SoftFloat {
         x
     }
 }
-
-macro_rules! impl_ops {
-    ($type:ident) => {
-        impl Default for $type {
-            fn default() -> Self {
-                num_traits::Zero::zero()
-            }
-        }
-
-        impl num_traits::Zero for $type {
-            fn zero() -> Self {
-                crate::SoftFloat::positive_zero()
-            }
-
-            fn is_zero(&self) -> bool {
-                crate::SoftFloat::is_zero(self)
-            }
-        }
-
-        impl num_traits::One for $type {
-            fn one() -> Self {
-                crate::SoftFloat::from_i8(1, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::Neg for $type {
-            type Output = Self;
-
-            fn neg(self) -> Self::Output {
-                crate::SoftFloat::neg(&self)
-            }
-        }
-
-        impl std::ops::Add for $type {
-            type Output = Self;
-
-            fn add(self, rhs: Self) -> Self::Output {
-                crate::SoftFloat::add(&self, rhs, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::AddAssign for $type {
-            fn add_assign(&mut self, rhs: Self) {
-                *self = *self + rhs;
-            }
-        }
-
-        impl std::ops::Sub for $type {
-            type Output = Self;
-
-            fn sub(self, rhs: Self) -> Self::Output {
-                crate::SoftFloat::sub(&self, rhs, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::SubAssign for $type {
-            fn sub_assign(&mut self, rhs: Self) {
-                *self = *self - rhs;
-            }
-        }
-
-        impl std::ops::Mul for $type {
-            type Output = Self;
-
-            fn mul(self, rhs: Self) -> Self::Output {
-                crate::SoftFloat::mul(&self, rhs, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::MulAssign for $type {
-            fn mul_assign(&mut self, rhs: Self) {
-                *self = *self * rhs;
-            }
-        }
-
-        impl std::ops::Div for $type {
-            type Output = Self;
-
-            fn div(self, rhs: Self) -> Self::Output {
-                crate::SoftFloat::div(&self, rhs, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::DivAssign for $type {
-            fn div_assign(&mut self, rhs: Self) {
-                *self = *self / rhs;
-            }
-        }
-
-        impl std::ops::Rem for $type {
-            type Output = Self;
-
-            fn rem(self, rhs: Self) -> Self::Output {
-                crate::SoftFloat::rem(&self, rhs, crate::DEFAULT_ROUNDING_MODE)
-            }
-        }
-
-        impl std::ops::RemAssign for $type {
-            fn rem_assign(&mut self, rhs: Self) {
-                *self = *self % rhs;
-            }
-        }
-
-        impl std::cmp::PartialEq for $type {
-            fn eq(&self, other: &Self) -> bool {
-                crate::SoftFloat::eq(self, other)
-            }
-        }
-
-        impl std::cmp::PartialOrd for $type {
-            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-                crate::SoftFloat::compare(self, other)
-            }
-        }
-    };
-}
-
-impl_ops!(F16);
-impl_ops!(F32);
-impl_ops!(F64);
-#[cfg(feature = "f128")]
-impl_ops!(F128);
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,12 @@
 //! }
 //! ```
 
-#[cfg(not(feature = "concordium"))]
+#[cfg(feature = "f128")]
 mod f128;
 mod f16;
 mod f32;
 mod f64;
-#[cfg(not(feature = "concordium"))]
+#[cfg(feature = "f128")]
 pub use crate::f128::F128;
 pub use crate::f16::F16;
 pub use crate::f32::F32;
@@ -184,10 +184,10 @@ pub trait SoftFloat {
     /// Exponent bits offset
     const EXPONENT_OFFSET: usize;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f32(value: f32) -> Self;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "native-float")]
     fn from_native_f64(value: f64) -> Self;
 
     fn set_payload(&mut self, x: Self::Payload);
@@ -249,7 +249,7 @@ pub trait SoftFloat {
 
     fn to_f64(&self, rnd: RoundingMode) -> F64;
 
-    #[cfg(not(feature = "concordium"))]
+    #[cfg(feature = "f128")]
     fn to_f128(&self, rnd: RoundingMode) -> F128;
 
     fn round_to_integral(&self, rnd: RoundingMode) -> Self;
@@ -492,29 +492,6 @@ pub trait SoftFloat {
 
 macro_rules! impl_ops {
     ($type:ident) => {
-        #[cfg(feature = "concordium")]
-        impl concordium_std::schema::SchemaType for $type {
-            fn get_type() -> concordium_std::schema::Type {
-                <<Self as crate::SoftFloat>::Payload as concordium_std::schema::SchemaType>::get_type()
-            }
-        }
-
-        #[cfg(feature = "concordium")]
-        impl concordium_std::Serial for $type {
-            fn serial<W: concordium_std::Write>(&self, out: &mut W) -> Result<(), W::Err> {
-                self.to_bits().serial(out)
-            }
-        }
-
-        #[cfg(feature = "concordium")]
-        impl concordium_std::Deserial for $type {
-            fn deserial<R: concordium_std::Read>(source: &mut R) -> concordium_std::ParseResult<Self> {
-                Ok(Self::from_bits(
-                    <Self as crate::SoftFloat>::Payload::deserial(source)?,
-                ))
-            }
-        }
-
         impl Default for $type {
             fn default() -> Self {
                 num_traits::Zero::zero()
@@ -632,7 +609,7 @@ macro_rules! impl_ops {
 impl_ops!(F16);
 impl_ops!(F32);
 impl_ops!(F64);
-#[cfg(not(feature = "concordium"))]
+#[cfg(feature = "f128")]
 impl_ops!(F128);
 
 #[cfg(test)]


### PR DESCRIPTION
1. Remove optional dep on `concordium-std` to remove future upgrade churn
2. Introduce `native-float` and `f128` feature gates, to actually control these two aspects
3. Add constant `from_bits`/`to_bits` functions form and to payload types
4. Remove operator default implementations. Client code should make decisions on rounding and exact modes itself
5. Replace arbitrary classifiers with single `classify`, use it in helper functions
6. Remove negative entities constructor funcs. Client code should use `smth().neg()` instead